### PR TITLE
fix: crypto to fiat bugs part2

### DIFF
--- a/src/components/invoice-form.tsx
+++ b/src/components/invoice-form.tsx
@@ -479,6 +479,19 @@ export function InvoiceForm({
     clientUserData,
   ]);
 
+  // Effect to disable Crypto-to-fiat when payment currency is not Sepolia USDC
+  useEffect(() => {
+    const paymentCurrency = form.watch("paymentCurrency");
+    const isCryptoToFiatEnabled = form.watch("isCryptoToFiatAvailable");
+
+    if (paymentCurrency !== "fUSDC-sepolia" && isCryptoToFiatEnabled) {
+      form.setValue("isCryptoToFiatAvailable", false);
+      // Clear payment details when disabling crypto-to-fiat
+      form.setValue("paymentDetailsId", "");
+      form.clearErrors("paymentDetailsId");
+    }
+  }, [form.watch, form.setValue, form.clearErrors]);
+
   // Extract submission logic into a separate function
   const submitAfterApproval = useCallback(() => {
     // Show success message
@@ -908,11 +921,37 @@ export function InvoiceForm({
                 form.clearErrors("paymentDetailsId");
               }
             }}
+            disabled={form.watch("paymentCurrency") !== "fUSDC-sepolia"}
+            className={
+              form.watch("paymentCurrency") !== "fUSDC-sepolia"
+                ? "opacity-50 cursor-not-allowed"
+                : ""
+            }
           />
-          <Label htmlFor="isCryptoToFiatAvailable">
+          <Label
+            htmlFor="isCryptoToFiatAvailable"
+            className={
+              form.watch("paymentCurrency") !== "fUSDC-sepolia"
+                ? "opacity-50 cursor-not-allowed"
+                : ""
+            }
+          >
             Allow payment to your bank account (Crypto-to-fiat payment)
           </Label>
         </div>
+        {form.watch("paymentCurrency") !== "fUSDC-sepolia" &&
+          form.watch("isCryptoToFiatAvailable") && (
+            <p className="text-xs text-amber-600">
+              Crypto-to-fiat is only available with Sepolia USDC. Changing
+              payment currency will disable this option.
+            </p>
+          )}
+        {form.watch("paymentCurrency") !== "fUSDC-sepolia" &&
+          !form.watch("isCryptoToFiatAvailable") && (
+            <p className="text-xs text-gray-500">
+              Crypto-to-fiat is only available with Sepolia USDC
+            </p>
+          )}
 
         {form.watch("isCryptoToFiatAvailable") &&
           (clientUserData?.isCompliant ? (

--- a/src/components/invoice-form.tsx
+++ b/src/components/invoice-form.tsx
@@ -490,7 +490,7 @@ export function InvoiceForm({
       form.setValue("paymentDetailsId", "");
       form.clearErrors("paymentDetailsId");
     }
-  }, [form.watch("paymentCurrency"), form.watch("isCryptoToFiatAvailable"), form]);
+  }, [form]);
 
   // Extract submission logic into a separate function
   const submitAfterApproval = useCallback(() => {

--- a/src/components/invoice-form.tsx
+++ b/src/components/invoice-form.tsx
@@ -821,6 +821,11 @@ export function InvoiceForm({
               {INVOICE_CURRENCIES.map((currency) => (
                 <SelectItem key={currency} value={currency}>
                   {formatCurrencyLabel(currency)}
+                  {currency === "fUSDC-sepolia" && (
+                    <span className="ml-2 text-xs text-green-600 font-medium">
+                      (works with Crypto-to-fiat)
+                    </span>
+                  )}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/components/invoice-form.tsx
+++ b/src/components/invoice-form.tsx
@@ -531,7 +531,7 @@ export function InvoiceForm({
         open={showBankAccountModal}
         onOpenChange={setShowBankAccountModal}
       >
-        <DialogContent className="max-w-3xl">
+        <DialogContent className="max-w-3xl overflow-y-auto max-h-[80vh]">
           <DialogHeader>
             <DialogTitle>Add Payment Method</DialogTitle>
           </DialogHeader>

--- a/src/components/invoice-form.tsx
+++ b/src/components/invoice-form.tsx
@@ -490,7 +490,7 @@ export function InvoiceForm({
       form.setValue("paymentDetailsId", "");
       form.clearErrors("paymentDetailsId");
     }
-  }, [form.watch, form.setValue, form.clearErrors]);
+  }, [form.watch("paymentCurrency"), form.watch("isCryptoToFiatAvailable"), form]);
 
   // Extract submission logic into a separate function
   const submitAfterApproval = useCallback(() => {

--- a/src/components/invoice-form.tsx
+++ b/src/components/invoice-form.tsx
@@ -954,20 +954,29 @@ export function InvoiceForm({
             </div>
           ))}
 
-        {!form.watch("isCryptoToFiatAvailable") && (
-          <div className="space-y-2">
-            <Label htmlFor="walletAddress">Your Wallet Address</Label>
-            <Input
-              {...form.register("walletAddress")}
-              placeholder="Enter your wallet address"
-            />
-            {form.formState.errors.walletAddress && (
-              <p className="text-sm text-red-500">
-                {form.formState.errors.walletAddress.message}
-              </p>
-            )}
-          </div>
-        )}
+        <div className="space-y-2">
+          <Label htmlFor="walletAddress">Your Wallet Address</Label>
+          <Input
+            {...form.register("walletAddress")}
+            placeholder="Enter your wallet address"
+            disabled={form.watch("isCryptoToFiatAvailable")}
+            className={
+              form.watch("isCryptoToFiatAvailable")
+                ? "opacity-50 cursor-not-allowed"
+                : ""
+            }
+          />
+          {form.watch("isCryptoToFiatAvailable") && (
+            <p className="text-xs text-gray-500">
+              Wallet address not required when using Crypto-to-fiat payment
+            </p>
+          )}
+          {form.formState.errors.walletAddress && (
+            <p className="text-sm text-red-500">
+              {form.formState.errors.walletAddress.message}
+            </p>
+          )}
+        </div>
 
         <div className="flex justify-end">
           <Button


### PR DESCRIPTION
## Changes

Fixes #58 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added labels and informational messages to clarify that Crypto-to-fiat payments are only available with Sepolia USDC.
  - The invoice currency selector now displays a note indicating compatibility with Crypto-to-fiat.
- **Improvements**
  - The payment method dialog now supports vertical scrolling with a maximum height for better usability.
  - Wallet address input is always visible but disabled and dimmed when Crypto-to-fiat is enabled, with an explanatory note.
  - The Crypto-to-fiat option is automatically disabled and visually dimmed when an unsupported currency is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->