### PR TITLE
feat: fix invoice me links

### DIFF
--- a/src/components/invoice-creator.tsx
+++ b/src/components/invoice-creator.tsx
@@ -107,6 +107,7 @@ export function InvoiceCreator({
             onSubmit={onSubmit}
             isLoading={isLoading}
             recipientDetails={recipientDetails}
+            isInvoiceMe={isInvoiceMe}
           />
         </CardContent>
       </Card>

--- a/src/components/invoice-form.tsx
+++ b/src/components/invoice-form.tsx
@@ -98,6 +98,7 @@ interface InvoiceFormProps {
     clientEmail: string;
     userId: string;
   };
+  isInvoiceMe: boolean;
 }
 
 // Payment Details Status Component
@@ -267,6 +268,7 @@ export function InvoiceForm({
   onSubmit,
   isLoading,
   recipientDetails,
+  isInvoiceMe,
 }: InvoiceFormProps) {
   const router = useRouter();
   const [showBankAccountModal, setShowBankAccountModal] = useState(false);
@@ -298,7 +300,11 @@ export function InvoiceForm({
   // Query to get payment details for the client
   const { data: paymentDetailsData, refetch: refetchPaymentDetails } =
     api.compliance.getPaymentDetails.useQuery(
-      { userId: currentUser.id ?? "" },
+      {
+        userId: isInvoiceMe
+          ? (recipientDetails?.userId ?? "")
+          : (currentUser.id ?? ""),
+      },
       {
         enabled: !!clientUserData?.id,
         // Use the configurable constant for polling interval


### PR DESCRIPTION
## Problem

The invoice me link page was trying to use current user to get compliance data, but in invoice me links there is no auth so curentUser is undefined by default.

## Solution

If invoice me link we use the recipient userId instead of current user to get the compliance data.