### PR TITLE
feat: make the 404 page nicer and implement 404 handling

### DIFF
--- a/src/app/i/[id]/helpers.ts
+++ b/src/app/i/[id]/helpers.ts
@@ -1,0 +1,13 @@
+import { isNotFoundError } from "@/lib/utils";
+import { api } from "@/trpc/server";
+
+export async function getInvoiceMeLink(id: string) {
+  try {
+    return await api.invoiceMe.getById.query(id);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/src/app/i/[id]/page.tsx
+++ b/src/app/i/[id]/page.tsx
@@ -3,11 +3,12 @@ import { Footer } from "@/components/footer";
 import { Header } from "@/components/header";
 import { InvoiceCreator } from "@/components/invoice-creator";
 import { getInvoiceCount } from "@/lib/helpers/invoice";
-import { api } from "@/trpc/server";
 import { ArrowLeft } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
+import { getInvoiceMeLink } from "./helpers";
+import { api } from "@/trpc/server";
 
 export const metadata: Metadata = {
   title: "Invoice Me | EasyInvoice",
@@ -20,9 +21,8 @@ export default async function InvoiceMePage({
   params: { id: string };
 }) {
   // TODO solve unauthenticated access
-  // TODO solve not found error like the subscription plan page
-  const invoiceMeLink = await api.invoiceMe.getById.query(params.id);
   const currentUser = await api.auth.getSessionInfo.query();
+  const invoiceMeLink = await getInvoiceMeLink(params.id);
 
   if (!invoiceMeLink) {
     notFound();

--- a/src/app/invoices/[ID]/helpers.ts
+++ b/src/app/invoices/[ID]/helpers.ts
@@ -1,0 +1,13 @@
+import { isNotFoundError } from "@/lib/utils";
+import { api } from "@/trpc/server";
+
+export async function getInvoice(id: string) {
+  try {
+    return await api.invoice.getById.query(id);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/src/app/invoices/[ID]/page.tsx
+++ b/src/app/invoices/[ID]/page.tsx
@@ -9,6 +9,7 @@ import { formatDate } from "@/lib/date-utils";
 import { api } from "@/trpc/server";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { getInvoice } from "./helpers";
 export const metadata: Metadata = {
   title: "Invoice Payment | EasyInvoice",
   description: "Process payment for your invoice",
@@ -25,7 +26,7 @@ export default async function PaymentPage({
 }: {
   params: { ID: string };
 }) {
-  const invoice = await api.invoice.getById.query(params.ID);
+  const invoice = await getInvoice(params.ID);
 
   if (!invoice) {
     notFound();

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,10 @@
-import { DollarSign, FileText, Home, Wallet, Zap } from "lucide-react";
+import { getCurrentSession } from "@/server/auth";
+import { DollarSign, FileText, Home, Lock, Wallet, Zap } from "lucide-react";
 import Link from "next/link";
 
-export default function NotFound() {
+export default async function NotFound() {
+  const { user } = await getCurrentSession();
+
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-6">
       <div className="max-w-2xl w-full text-center">
@@ -20,17 +23,17 @@ export default function NotFound() {
             </span>
           </div>
           <p className="text-gray-600 mb-2">
-            This page seems to have been sent to a non-existent wallet address.
+            The page you're looking for doesn't exist or may have been moved.
           </p>
           <p className="text-gray-600">
-            Don't worry, your invoices are safe and sound!{" "}
+            Your account and invoices remain secure.
           </p>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
           <Link
             href="/payouts"
-            className="shadow-md group p-6 bg-white rounded-lg border border-gray-200 hover:border-gray-300 transition-colors"
+            className="shadow-md group p-6 bg-white rounded-lg border border-gray-200 hover:border-gray-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"
           >
             <div className="w-12 h-12 rounded-lg bg-blue-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-blue-200 transition-colors">
               <DollarSign className="w-6 h-6 text-blue-600" />
@@ -41,36 +44,68 @@ export default function NotFound() {
             </p>
           </Link>
 
-          <Link
-            href="/invoices/create"
-            className="shadow-md group p-6 bg-white rounded-lg border border-gray-200 hover:border-gray-300 transition-colors"
-          >
-            <div className="w-12 h-12 rounded-lg bg-purple-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-purple-200 transition-colors">
-              <Zap className="w-6 h-6 text-purple-600" />
+          {user ? (
+            <Link
+              href="/invoices/create"
+              className="shadow-md group p-6 bg-white rounded-lg border border-gray-200 hover:border-gray-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"
+            >
+              <div className="w-12 h-12 rounded-lg bg-purple-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-purple-200 transition-colors">
+                <Zap className="w-6 h-6 text-purple-600" />
+              </div>
+              <h3 className="font-semibold text-gray-900 mb-2">
+                Create Invoice
+              </h3>
+              <p className="text-sm text-gray-600">
+                Start a new payment request
+              </p>
+            </Link>
+          ) : (
+            <div className="shadow-md p-6 bg-white rounded-lg border border-gray-200 opacity-75 cursor-not-allowed">
+              <div className="w-12 h-12 rounded-lg bg-gray-100 flex items-center justify-center mx-auto mb-4">
+                <Lock className="w-6 h-6 text-gray-500" />
+              </div>
+              <h3 className="font-semibold text-gray-900 mb-2">
+                Sign in to create invoices
+              </h3>
+              <p className="text-sm text-gray-600">
+                Start a new payment request
+              </p>
             </div>
-            <h3 className="font-semibold text-gray-900 mb-2">Create Invoice</h3>
-            <p className="text-sm text-gray-600">Start a new payment request</p>
-          </Link>
+          )}
 
-          <Link
-            href="/subscription-plans"
-            className="shadow-md group p-6 bg-white rounded-lg border border-gray-200 hover:border-gray-300 transition-colors"
-          >
-            <div className="w-12 h-12 rounded-lg bg-green-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-green-200 transition-colors">
-              <FileText className="w-6 h-6 text-green-600" />
+          {user ? (
+            <Link
+              href="/subscription-plans"
+              className="shadow-md group p-6 bg-white rounded-lg border border-gray-200 hover:border-gray-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"
+            >
+              <div className="w-12 h-12 rounded-lg bg-green-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-green-200 transition-colors">
+                <FileText className="w-6 h-6 text-green-600" />
+              </div>
+              <h3 className="font-semibold text-gray-900 mb-2">
+                Subscription Plans
+              </h3>
+              <p className="text-sm text-gray-600">
+                Manage your subscription plans
+              </p>
+            </Link>
+          ) : (
+            <div className="shadow-md p-6 bg-white rounded-lg border border-gray-200 opacity-75 cursor-not-allowed">
+              <div className="w-12 h-12 rounded-lg bg-gray-100 flex items-center justify-center mx-auto mb-4">
+                <Lock className="w-6 h-6 text-gray-500" />
+              </div>
+              <h3 className="font-semibold text-gray-900 mb-2">
+                Sign in to manage subscription plans
+              </h3>
+              <p className="text-sm text-gray-600">
+                View and manage your subscription options
+              </p>
             </div>
-            <h3 className="font-semibold text-gray-900 mb-2">
-              Subscription Plans
-            </h3>
-            <p className="text-sm text-gray-600">
-              Manage your subscription plans
-            </p>
-          </Link>
+          )}
         </div>
 
         <Link
           href="/dashboard"
-          className="inline-flex items-center gap-2 px-6 py-3 bg-black text-white font-medium rounded-lg hover:bg-gray-800 transition-colors duration-200"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-black text-white font-medium rounded-lg hover:bg-gray-800 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"
         >
           <Home className="w-4 h-4" />
           Back to Dashboard

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,25 +1,82 @@
+import { DollarSign, FileText, Home, Wallet, Zap } from "lucide-react";
 import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="max-w-md w-full text-center">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-6">
+      <div className="max-w-2xl w-full text-center">
         <div className="mb-8">
-          <h1 className="text-6xl font-bold text-gray-900 mb-4">404</h1>
-          <h2 className="text-2xl font-semibold text-gray-700 mb-2">
-            Not Found
-          </h2>
-          <p className="text-gray-600">
-            Sorry, we couldn't find the page you're looking for.
+          <div className="w-16 h-16 rounded-xl bg-black flex items-center justify-center mx-auto mb-6">
+            <span className="text-white font-bold text-xl">EI</span>
+          </div>
+        </div>
+
+        <div className="mb-8">
+          <h1 className="text-8xl font-bold text-gray-900 mb-4">404</h1>
+          <div className="flex items-center justify-center gap-2 mb-4">
+            <Wallet className="w-5 h-5 text-gray-600" />
+            <span className="text-lg font-medium text-gray-700">
+              Transaction Not Found
+            </span>
+          </div>
+          <p className="text-gray-600 mb-2">
+            Looks like this page got lost in the blockchain. Don't
           </p>
+          <p className="text-gray-600">worry, your funds are safe!</p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+          <Link
+            href="/payouts"
+            className="shadow-md group p-6 bg-white rounded-lg border border-gray-200 hover:border-gray-300 transition-colors"
+          >
+            <div className="w-12 h-12 rounded-lg bg-blue-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-blue-200 transition-colors">
+              <DollarSign className="w-6 h-6 text-blue-600" />
+            </div>
+            <h3 className="font-semibold text-gray-900 mb-2">Payouts</h3>
+            <p className="text-sm text-gray-600">
+              Find your invoices and payments
+            </p>
+          </Link>
+
+          <Link
+            href="/invoices/create"
+            className="shadow-md group p-6 bg-white rounded-lg border border-gray-200 hover:border-gray-300 transition-colors"
+          >
+            <div className="w-12 h-12 rounded-lg bg-purple-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-purple-200 transition-colors">
+              <Zap className="w-6 h-6 text-purple-600" />
+            </div>
+            <h3 className="font-semibold text-gray-900 mb-2">Create Invoice</h3>
+            <p className="text-sm text-gray-600">Start a new payment request</p>
+          </Link>
+
+          <Link
+            href="/subscription-plans"
+            className="shadow-md group p-6 bg-white rounded-lg border border-gray-200 hover:border-gray-300 transition-colors"
+          >
+            <div className="w-12 h-12 rounded-lg bg-green-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-green-200 transition-colors">
+              <FileText className="w-6 h-6 text-green-600" />
+            </div>
+            <h3 className="font-semibold text-gray-900 mb-2">
+              Subscription Plans
+            </h3>
+            <p className="text-sm text-gray-600">
+              Manage your subscription plans
+            </p>
+          </Link>
         </div>
 
         <Link
-          href="/"
-          className="inline-flex items-center px-6 py-3 bg-primary text-white font-medium rounded-lg hover:bg-blue-700 transition-colors duration-200"
+          href="/dashboard"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-black text-white font-medium rounded-lg hover:bg-gray-800 transition-colors duration-200"
         >
-          Go Home
+          <Home className="w-4 h-4" />
+          Back to Dashboard
         </Link>
+
+        <div className="mt-8 text-sm text-gray-400 font-mono">
+          <span>Error Code: 0x404 • Block not found in this chain</span>
+        </div>
       </div>
     </div>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -16,13 +16,15 @@ export default function NotFound() {
           <div className="flex items-center justify-center gap-2 mb-4">
             <Wallet className="w-5 h-5 text-gray-600" />
             <span className="text-lg font-medium text-gray-700">
-              Transaction Not Found
+              Page Not Found
             </span>
           </div>
           <p className="text-gray-600 mb-2">
-            Looks like this page got lost in the blockchain. Don't
+            This page seems to have been sent to a non-existent wallet address.
           </p>
-          <p className="text-gray-600">worry, your funds are safe!</p>
+          <p className="text-gray-600">
+            Don't worry, your invoices are safe and sound!{" "}
+          </p>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
@@ -35,7 +37,7 @@ export default function NotFound() {
             </div>
             <h3 className="font-semibold text-gray-900 mb-2">Payouts</h3>
             <p className="text-sm text-gray-600">
-              Find your invoices and payments
+              Single, batch or recurring payouts
             </p>
           </Link>
 
@@ -73,10 +75,6 @@ export default function NotFound() {
           <Home className="w-4 h-4" />
           Back to Dashboard
         </Link>
-
-        <div className="mt-8 text-sm text-gray-400 font-mono">
-          <span>Error Code: 0x404 • Block not found in this chain</span>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Problem
Our 404 page is rudimentary and we do not have not found handling when we fetch invoices and invoice me links.

## Solution
Upgrade the design and handle 404 when the id from parameters yields no results.

## Changes
- Redesigned the 404 page (I hope it's tastefully quirky)
<img width="1657" height="1392" alt="image" src="https://github.com/user-attachments/assets/6eb8610b-71ad-4be5-81ad-5d7d5e854ddc" />
- Added not found handling for the invoices/:id page
- Added not found handling for the i/:id page

## Testing
1. Go to `/invalid-route` or whatever, and verify the 404 page shows up
<img width="2860" height="1509" alt="image" src="https://github.com/user-attachments/assets/79f0d9c8-952d-4a0a-a4a7-d64405bafdd9" />
2. Go to `/i/not-a-valid-id` and verify the 404 page shows up
<img width="2851" height="1493" alt="image" src="https://github.com/user-attachments/assets/56f75b66-d813-4f8c-80d3-5273e00d8ed7" />
3. Go to `/invoices/not-a-valid-id` and verify that the 404 page shows up
<img width="2848" height="1470" alt="image" src="https://github.com/user-attachments/assets/f26804d8-374b-4a94-8ee9-fa79b9fccfc1" />
4. Verify that the links on the 404 page work properly
5. If you are logged out, verify that the second two cards are disabled
<img width="915" height="901" alt="image" src="https://github.com/user-attachments/assets/2f0f9555-beca-4ae0-b0c0-e4384157cb75" />


Resolves #108 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned 404 page with updated branding, larger heading, clearer messaging, and a three-card grid linking to Payouts, Create Invoice, and Subscription Plans; cards adapt based on sign-in state. NotFound is now an async server component.
* **Refactor**
  * Invoice and payment pages now use centralized helper functions for fetching invoices, with graceful handling when an invoice is not found while preserving existing page behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->