### PR TITLE
feat: autofill user name and email if they're logged in in invoiceme

### DIFF
--- a/src/components/invoice-creator.tsx
+++ b/src/components/invoice-creator.tsx
@@ -81,8 +81,8 @@ export function InvoiceCreator({
     defaultValues: {
       invoiceNumber: generateInvoiceNumber(invoiceCount),
       dueDate: "",
-      creatorName: !isInvoiceMe ? (currentUser?.name ?? "") : "",
-      creatorEmail: !isInvoiceMe ? (currentUser?.email ?? "") : "",
+      creatorName: currentUser?.name ?? "",
+      creatorEmail: currentUser?.email ?? "",
       clientName: recipientDetails?.clientName ?? "",
       clientEmail: recipientDetails?.clientEmail ?? "",
       invoicedTo: recipientDetails?.userId ?? "",

--- a/src/server/routers/invoice.ts
+++ b/src/server/routers/invoice.ts
@@ -148,7 +148,7 @@ export const invoiceRouter = router({
   createFromInvoiceMe: publicProcedure
     .input(invoiceFormSchema)
     .mutation(async ({ ctx, input }) => {
-      const { db } = ctx;
+      const { db, session } = ctx;
 
       if (!input.invoicedTo) {
         throw new TRPCError({
@@ -177,7 +177,7 @@ export const invoiceRouter = router({
             {
               ...input,
             },
-            input.invoicedTo as string,
+            session?.userId || (input?.invoicedTo as string),
           );
         });
       } catch (error) {


### PR DESCRIPTION
### Problem

If a user is logged in and trying to create an invoice in InvoiceMe link they have to fill in the name and email manually

### Solution:

Autofill the information automatically

<img width="1422" height="962" alt="CleanShot 2025-08-28 at 13 05 21" src="https://github.com/user-attachments/assets/b9f1556d-ccce-4ecc-b3ba-12be04148f32" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Creator name and email now auto-fill from your profile across all invoice creation flows, reducing manual entry.

* **Bug Fixes**
  * Invoices created via “Invoice Me” now correctly associate with your logged-in account when available, while still targeting the chosen recipient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->