### PR TITLE
Feat: ecommerce sales and user's receipts

### DIFF
--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1759323380579,
       "tag": "0009_slippery_penance",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1759491911320,
+      "tag": "0010_minor_roulette",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -53,6 +53,7 @@ async function addClientPayment(webhookBody: any) {
     await tx.insert(clientPaymentTable).values({
       id: ulid(),
       userId: client.userId,
+      ecommerceClientId: client.id,
       requestId: webhookBody.requestId,
       invoiceCurrency: webhookBody.currency,
       paymentCurrency: webhookBody.paymentCurrency,
@@ -61,7 +62,6 @@ async function addClientPayment(webhookBody: any) {
       amount: webhookBody.amount,
       customerInfo: webhookBody.customerInfo || null,
       reference: webhookBody.reference || null,
-      clientId: webhookBody.clientId,
       origin: webhookBody.origin,
     });
   });

--- a/src/app/dashboard/receipts/page.tsx
+++ b/src/app/dashboard/receipts/page.tsx
@@ -1,0 +1,16 @@
+import { DashboardReceipts } from "@/components/dashboard/receipts";
+import { getCurrentSession } from "@/server/auth";
+import { api } from "@/trpc/server";
+import { redirect } from "next/navigation";
+
+export default async function ReceiptsPage() {
+  const { user } = await getCurrentSession();
+
+  if (!user) {
+    redirect("/");
+  }
+
+  const clientPayments = await api.ecommerce.getAllUserReceipts.query();
+
+  return <DashboardReceipts initialClientPayments={clientPayments} />;
+}

--- a/src/app/ecommerce/sales/page.tsx
+++ b/src/app/ecommerce/sales/page.tsx
@@ -1,5 +1,6 @@
+import { EcommerceSales } from "@/components/ecommerce/sales";
 import { getCurrentSession } from "@/server/auth";
-//import { api } from "@/trpc/server";
+import { api } from "@/trpc/server";
 import { redirect } from "next/navigation";
 
 export default async function SalesPage() {
@@ -9,7 +10,15 @@ export default async function SalesPage() {
     redirect("/");
   }
 
-  // TODO fetch sales data
+  const [clientPayments, ecommerceClients] = await Promise.all([
+    api.ecommerce.getAllClientPayments.query(),
+    api.ecommerce.getAll.query(),
+  ]);
 
-  return <div>Sales Page - to be implemented</div>;
+  return (
+    <EcommerceSales
+      initialClientPayments={clientPayments}
+      ecommerceClients={ecommerceClients}
+    />
+  );
 }

--- a/src/app/ecommerce/sales/page.tsx
+++ b/src/app/ecommerce/sales/page.tsx
@@ -10,15 +10,7 @@ export default async function SalesPage() {
     redirect("/");
   }
 
-  const [clientPayments, ecommerceClients] = await Promise.all([
-    api.ecommerce.getAllClientPayments.query(),
-    api.ecommerce.getAll.query(),
-  ]);
+  const clientPayments = await api.ecommerce.getAllClientPayments.query();
 
-  return (
-    <EcommerceSales
-      initialClientPayments={clientPayments}
-      ecommerceClients={ecommerceClients}
-    />
-  );
+  return <EcommerceSales initialClientPayments={clientPayments} />;
 }

--- a/src/components/dashboard-navigation.tsx
+++ b/src/components/dashboard-navigation.tsx
@@ -14,6 +14,8 @@ export function DashboardNavigation() {
       setActiveTab("pay");
     } else if (pathname.includes("/subscriptions")) {
       setActiveTab("subscriptions");
+    } else if (pathname.includes("/receipts")) {
+      setActiveTab("receipts");
     } else {
       setActiveTab("get-paid");
     }
@@ -21,7 +23,7 @@ export function DashboardNavigation() {
 
   return (
     <Tabs value={activeTab} className="w-full mb-8">
-      <TabsList className="grid w-full grid-cols-3">
+      <TabsList className="grid w-full grid-cols-4">
         <TabsTrigger value="get-paid" asChild>
           <Link href="/dashboard/get-paid">Get Paid</Link>
         </TabsTrigger>
@@ -30,6 +32,9 @@ export function DashboardNavigation() {
         </TabsTrigger>
         <TabsTrigger value="subscriptions" asChild>
           <Link href="/dashboard/subscriptions">Subscriptions</Link>
+        </TabsTrigger>
+        <TabsTrigger value="receipts" asChild>
+          <Link href="/dashboard/receipts">Receipts</Link>
         </TabsTrigger>
       </TabsList>
     </Tabs>

--- a/src/components/dashboard/receipts.tsx
+++ b/src/components/dashboard/receipts.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import type { ClientPayment } from "@/server/db/schema";
+
+interface DashboardReceiptsProps {
+  initialClientPayments: ClientPayment[];
+}
+
+export function DashboardReceipts({
+  initialClientPayments,
+}: DashboardReceiptsProps) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">My Receipts</h1>
+        <p className="text-sm text-muted-foreground">
+          View all your payment receipts from ecommerce transactions
+        </p>
+      </div>
+      <div className="p-8 bg-zinc-50 rounded-lg text-center">
+        <p className="text-zinc-600">Receipts component coming soon...</p>
+        <p className="text-sm text-zinc-500 mt-2">
+          Found {initialClientPayments.length} payment receipts
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/receipts.tsx
+++ b/src/components/dashboard/receipts.tsx
@@ -1,28 +1,186 @@
 "use client";
 
-import type { ClientPayment } from "@/server/db/schema";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { EmptyState } from "@/components/ui/table/empty-state";
+import { Pagination } from "@/components/ui/table/pagination";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table/table";
+import { TableHeadCell } from "@/components/ui/table/table-head-cell";
+import type { ClientPaymentWithEcommerceClient } from "@/lib/types";
+import { api } from "@/trpc/react";
+import { format } from "date-fns";
+import { Filter, Receipt } from "lucide-react";
+import { useState } from "react";
+import { ErrorState } from "../ui/table/error-state";
 
 interface DashboardReceiptsProps {
-  initialClientPayments: ClientPayment[];
+  initialClientPayments: ClientPaymentWithEcommerceClient[];
 }
+
+const ReceiptTableColumns = () => (
+  <TableRow className="hover:bg-transparent border-none">
+    <TableHeadCell>Date</TableHeadCell>
+    <TableHeadCell>Reference</TableHeadCell>
+    <TableHeadCell>Amount</TableHeadCell>
+    <TableHeadCell>Payment Currency</TableHeadCell>
+    <TableHeadCell>Network</TableHeadCell>
+    <TableHeadCell>Merchant</TableHeadCell>
+  </TableRow>
+);
+
+const ReceiptRow = ({
+  receipt,
+}: { receipt: ClientPaymentWithEcommerceClient }) => {
+  return (
+    <TableRow className="hover:bg-zinc-50/50">
+      <TableCell>
+        {receipt.createdAt
+          ? format(new Date(receipt.createdAt), "do MMM yyyy")
+          : "N/A"}
+      </TableCell>
+      <TableCell>
+        {receipt.reference || <span className="text-zinc-500">-</span>}
+      </TableCell>
+      <TableCell className="font-medium">{receipt.amount}</TableCell>
+      <TableCell>{receipt.paymentCurrency}</TableCell>
+      <TableCell>{receipt.network}</TableCell>
+      <TableCell>{receipt.ecommerceClient.label}</TableCell>
+    </TableRow>
+  );
+};
+
+const ITEMS_PER_PAGE = 10;
 
 export function DashboardReceipts({
   initialClientPayments,
 }: DashboardReceiptsProps) {
+  const [activeClientId, setActiveClientId] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const { data, error, refetch, isRefetching } =
+    api.ecommerce.getAllUserReceipts.useQuery(undefined, {
+      initialData: initialClientPayments,
+      refetchOnMount: true,
+    });
+
+  if (error) {
+    return (
+      <ErrorState
+        onRetry={refetch}
+        isRetrying={isRefetching}
+        explanation="We couldn't load the receipts data. Please try again."
+      />
+    );
+  }
+
+  const receipts = data || [];
+
+  const filteredReceipts = activeClientId
+    ? receipts.filter((receipt) => receipt.ecommerceClientId === activeClientId)
+    : receipts;
+
+  const totalPages = Math.ceil(filteredReceipts.length / ITEMS_PER_PAGE);
+  const paginatedReceipts = filteredReceipts.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE,
+  );
+
+  const handleClientFilterChange = (value: string) => {
+    setActiveClientId(value === "all" ? null : value);
+    setCurrentPage(1);
+  };
+
+  const ecommerceClients = receipts.reduce(
+    (acc, receipt) => {
+      if (acc[receipt.ecommerceClient.id]) return acc;
+      acc[receipt.ecommerceClient.id] = receipt.ecommerceClient;
+      return acc;
+    },
+    {} as Record<string, ClientPaymentWithEcommerceClient["ecommerceClient"]>,
+  );
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">My Receipts</h1>
-        <p className="text-sm text-muted-foreground">
-          View all your payment receipts from ecommerce transactions
-        </p>
+      <p className="text-sm text-muted-foreground">
+        View all your payment receipts from ecommerce transactions
+      </p>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <Filter className="h-4 w-4 text-zinc-600" />
+            <span className="text-sm font-medium text-zinc-700">
+              Filter by merchant:
+            </span>
+          </div>
+          <Select
+            value={activeClientId || "all"}
+            onValueChange={handleClientFilterChange}
+          >
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="All Merchants" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Merchants</SelectItem>
+              {Object.entries(ecommerceClients).map(([clientId, client]) => (
+                <SelectItem key={clientId} value={clientId}>
+                  {client.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </div>
-      <div className="p-8 bg-zinc-50 rounded-lg text-center">
-        <p className="text-zinc-600">Receipts component coming soon...</p>
-        <p className="text-sm text-zinc-500 mt-2">
-          Found {initialClientPayments.length} payment receipts
-        </p>
-      </div>
+      <Card className="border border-zinc-100">
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <ReceiptTableColumns />
+            </TableHeader>
+            <TableBody>
+              {paginatedReceipts.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="p-0">
+                    <EmptyState
+                      icon={<Receipt className="h-6 w-6 text-zinc-600" />}
+                      title="No receipts"
+                      subtitle={
+                        activeClientId
+                          ? "No receipts found for the selected merchant"
+                          : "You haven't received any payments yet"
+                      }
+                    />
+                  </TableCell>
+                </TableRow>
+              ) : (
+                paginatedReceipts.map((receipt) => (
+                  <ReceiptRow key={receipt.id} receipt={receipt} />
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {totalPages > 1 && (
+        <Pagination
+          page={currentPage}
+          totalItems={filteredReceipts.length}
+          itemsPerPage={ITEMS_PER_PAGE}
+          setPage={setCurrentPage}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/dashboard/receipts.tsx
+++ b/src/components/dashboard/receipts.tsx
@@ -73,6 +73,7 @@ export function DashboardReceipts({
     api.ecommerce.getAllUserReceipts.useQuery(undefined, {
       initialData: initialClientPayments,
       refetchOnMount: true,
+      refetchInterval: 10000,
     });
 
   if (error) {

--- a/src/components/ecommerce/sales/blocks/client-payments-table.tsx
+++ b/src/components/ecommerce/sales/blocks/client-payments-table.tsx
@@ -229,7 +229,7 @@ export function ClientPaymentsTable({
             <TableBody>
               {paginatedPayments.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={9} className="p-0">
+                  <TableCell colSpan={10} className="p-0">
                     <EmptyState
                       icon={<CreditCard className="h-6 w-6 text-zinc-600" />}
                       title="No client payments"

--- a/src/components/ecommerce/sales/blocks/client-payments-table.tsx
+++ b/src/components/ecommerce/sales/blocks/client-payments-table.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { ShortAddress } from "@/components/short-address";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { EmptyState } from "@/components/ui/table/empty-state";
+import { Pagination } from "@/components/ui/table/pagination";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table/table";
+import { TableHeadCell } from "@/components/ui/table/table-head-cell";
+import type { ClientPayment, EcommerceClient } from "@/server/db/schema";
+import { format } from "date-fns";
+import {
+  ChevronDown,
+  ChevronUp,
+  CreditCard,
+  ExternalLink,
+  Filter,
+} from "lucide-react";
+import { useState } from "react";
+
+interface ClientPaymentsTableProps {
+  clientPayments: ClientPayment[];
+  ecommerceClients: EcommerceClient[];
+}
+
+interface CustomerInfoDisplayProps {
+  customerInfo: ClientPayment["customerInfo"];
+}
+
+function CustomerInfoDisplay({ customerInfo }: CustomerInfoDisplayProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (!customerInfo) {
+    return <span className="text-zinc-500">-</span>;
+  }
+
+  const hasExpandableInfo =
+    customerInfo.firstName || customerInfo.lastName || customerInfo.address;
+
+  return (
+    <div className="space-y-2">
+      <div className="text-sm">{customerInfo.email || "No email"}</div>
+      {hasExpandableInfo && (
+        <>
+          {isExpanded && (
+            <div className="space-y-1 text-xs text-zinc-600 font-normal">
+              {(customerInfo.firstName || customerInfo.lastName) && (
+                <div>
+                  {customerInfo.firstName} {customerInfo.lastName}
+                </div>
+              )}
+              {customerInfo.address && (
+                <div className="space-y-1">
+                  {customerInfo.address.street && (
+                    <div>{customerInfo.address.street}</div>
+                  )}
+                  <div>
+                    {customerInfo.address.city}, {customerInfo.address.state}{" "}
+                    {customerInfo.address.postalCode}
+                  </div>
+                  {customerInfo.address.country && (
+                    <div>{customerInfo.address.country}</div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="h-6 px-2 text-xs"
+          >
+            {isExpanded ? (
+              <>
+                <ChevronUp className="h-3 w-3 mr-1" />
+                Collapse
+              </>
+            ) : (
+              <>
+                <ChevronDown className="h-3 w-3 mr-1" />
+                Show details
+              </>
+            )}
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}
+
+const ClientPaymentTableColumns = () => (
+  <TableRow className="hover:bg-transparent border-none">
+    <TableHeadCell>Date</TableHeadCell>
+    <TableHeadCell>Amount</TableHeadCell>
+    <TableHeadCell>Network</TableHeadCell>
+    <TableHeadCell>Invoice Currency</TableHeadCell>
+    <TableHeadCell>Payment Currency</TableHeadCell>
+    <TableHeadCell>Customer Info</TableHeadCell>
+    <TableHeadCell>Reference</TableHeadCell>
+    <TableHeadCell>Client ID</TableHeadCell>
+    <TableHeadCell>Origin</TableHeadCell>
+    <TableHeadCell>Request Scan URL</TableHeadCell>
+  </TableRow>
+);
+
+const ClientPaymentRow = ({
+  clientPayment,
+}: { clientPayment: ClientPayment }) => {
+  return (
+    <TableRow className="hover:bg-zinc-50/50">
+      <TableCell>
+        {clientPayment.createdAt
+          ? format(new Date(clientPayment.createdAt), "do MMM yyyy HH:mm")
+          : "N/A"}
+      </TableCell>
+      <TableCell className="font-medium">{clientPayment.amount}</TableCell>
+      <TableCell>{clientPayment.network}</TableCell>
+      <TableCell>{clientPayment.invoiceCurrency}</TableCell>
+      <TableCell>{clientPayment.paymentCurrency}</TableCell>
+      <TableCell>
+        <CustomerInfoDisplay customerInfo={clientPayment.customerInfo} />
+      </TableCell>
+      <TableCell>
+        {clientPayment.reference || <span className="text-zinc-500">-</span>}
+      </TableCell>
+      <TableCell>
+        <ShortAddress address={clientPayment.clientId} />
+      </TableCell>
+      <TableCell>
+        {clientPayment.origin || <span className="text-zinc-500">-</span>}
+      </TableCell>
+      <TableCell>
+        <a
+          href={`https://scan.request.network/request/${clientPayment.requestId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 transition-colors"
+        >
+          <span className="text-sm">View Request</span>
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      </TableCell>
+    </TableRow>
+  );
+};
+
+const ITEMS_PER_PAGE = 10;
+export function ClientPaymentsTable({
+  clientPayments,
+  ecommerceClients,
+}: ClientPaymentsTableProps) {
+  const [activeClientId, setActiveClientId] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const filteredPayments = activeClientId
+    ? clientPayments.filter((payment) => payment.clientId === activeClientId)
+    : clientPayments;
+
+  const totalPages = Math.ceil(filteredPayments.length / ITEMS_PER_PAGE);
+  const paginatedPayments = filteredPayments.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE,
+  );
+
+  const handleClientFilterChange = (value: string) => {
+    setActiveClientId(value === "all" ? null : value);
+    setCurrentPage(1);
+  };
+
+  const clientIdToLabel = ecommerceClients.reduce(
+    (acc, client) => {
+      acc[client.rnClientId] = client.label;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+
+  const uniqueClientIds = Array.from(
+    new Set(clientPayments.map((payment) => payment.clientId)),
+  );
+
+  return (
+    <div className="space-y-6 w-full">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <Filter className="h-4 w-4 text-zinc-600" />
+            <span className="text-sm font-medium text-zinc-700">
+              Filter by client:
+            </span>
+          </div>
+          <Select
+            value={activeClientId || "all"}
+            onValueChange={handleClientFilterChange}
+          >
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="All Clients" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Clients</SelectItem>
+              {uniqueClientIds.map((clientId) => (
+                <SelectItem key={clientId} value={clientId}>
+                  {clientIdToLabel[clientId] || `${clientId.slice(0, 8)}...`}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <Card className="border border-zinc-100">
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <ClientPaymentTableColumns />
+            </TableHeader>
+            <TableBody>
+              {paginatedPayments.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={9} className="p-0">
+                    <EmptyState
+                      icon={<CreditCard className="h-6 w-6 text-zinc-600" />}
+                      title="No client payments"
+                      subtitle={
+                        activeClientId
+                          ? "No payments found for the selected client"
+                          : "No payments received yet"
+                      }
+                    />
+                  </TableCell>
+                </TableRow>
+              ) : (
+                paginatedPayments.map((clientPayment) => (
+                  <ClientPaymentRow
+                    key={clientPayment.id}
+                    clientPayment={clientPayment}
+                  />
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {totalPages > 1 && (
+        <Pagination
+          page={currentPage}
+          totalItems={filteredPayments.length}
+          itemsPerPage={ITEMS_PER_PAGE}
+          setPage={setCurrentPage}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ecommerce/sales/index.tsx
+++ b/src/components/ecommerce/sales/index.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { ErrorState } from "@/components/ui/table/error-state";
+import type { ClientPayment, EcommerceClient } from "@/server/db/schema";
+import { api } from "@/trpc/react";
+import { ClientPaymentsTable } from "./blocks/client-payments-table";
+
+interface EcommerceSalesProps {
+  initialClientPayments: ClientPayment[];
+  ecommerceClients: EcommerceClient[];
+}
+
+export function EcommerceSales({
+  initialClientPayments,
+  ecommerceClients,
+}: EcommerceSalesProps) {
+  const { data, error, refetch, isRefetching } =
+    api.ecommerce.getAllClientPayments.useQuery(undefined, {
+      initialData: initialClientPayments,
+      refetchOnMount: true,
+    });
+
+  if (error) {
+    return (
+      <ErrorState
+        onRetry={refetch}
+        isRetrying={isRefetching}
+        explanation="We couldn't load the client payments data. Please try again."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Client Payments</h1>
+        <p className="text-sm text-muted-foreground">
+          View all payments received through your ecommerce integrations
+        </p>
+      </div>
+      <ClientPaymentsTable
+        clientPayments={data}
+        ecommerceClients={ecommerceClients}
+      />
+    </div>
+  );
+}

--- a/src/components/ecommerce/sales/index.tsx
+++ b/src/components/ecommerce/sales/index.tsx
@@ -14,6 +14,7 @@ export function EcommerceSales({ initialClientPayments }: EcommerceSalesProps) {
     api.ecommerce.getAllClientPayments.useQuery(undefined, {
       initialData: initialClientPayments,
       refetchOnMount: true,
+      refetchInterval: 10000,
     });
 
   if (error) {

--- a/src/components/ecommerce/sales/index.tsx
+++ b/src/components/ecommerce/sales/index.tsx
@@ -1,19 +1,15 @@
 "use client";
 
 import { ErrorState } from "@/components/ui/table/error-state";
-import type { ClientPayment, EcommerceClient } from "@/server/db/schema";
+import type { ClientPaymentWithEcommerceClient } from "@/lib/types";
 import { api } from "@/trpc/react";
 import { ClientPaymentsTable } from "./blocks/client-payments-table";
 
 interface EcommerceSalesProps {
-  initialClientPayments: ClientPayment[];
-  ecommerceClients: EcommerceClient[];
+  initialClientPayments: ClientPaymentWithEcommerceClient[];
 }
 
-export function EcommerceSales({
-  initialClientPayments,
-  ecommerceClients,
-}: EcommerceSalesProps) {
+export function EcommerceSales({ initialClientPayments }: EcommerceSalesProps) {
   const { data, error, refetch, isRefetching } =
     api.ecommerce.getAllClientPayments.useQuery(undefined, {
       initialData: initialClientPayments,
@@ -38,10 +34,7 @@ export function EcommerceSales({
           View all payments received through your ecommerce integrations
         </p>
       </div>
-      <ClientPaymentsTable
-        clientPayments={data}
-        ecommerceClients={ecommerceClients}
-      />
+      <ClientPaymentsTable clientPayments={data} />
     </div>
   );
 }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,4 +1,6 @@
 import type { RecurringPayment } from "@/server/db/schema";
+import type { ecommerceRouter } from "@/server/routers/ecommerce";
+import type { inferRouterOutputs } from "@trpc/server";
 
 export interface PaymentRoute {
   id: string;
@@ -33,3 +35,7 @@ export type SubscriptionPayment = {
   totalNumberOfPayments: number;
   paymentNumber: number;
 };
+
+export type ClientPaymentWithEcommerceClient = inferRouterOutputs<
+  typeof ecommerceRouter
+>["getAllClientPayments"][number];

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -177,41 +177,6 @@ export const paymentDetailsPayersTable = createTable("payment_details_payers", {
   createdAt: timestamp("created_at").defaultNow(),
 });
 
-export const clientPaymentTable = createTable("client_payment", {
-  id: text().primaryKey().notNull(),
-  userId: text()
-    .notNull()
-    .references(() => userTable.id, {
-      onDelete: "cascade",
-    }),
-  requestId: text().notNull(),
-  ecommerceClientId: text()
-    .notNull()
-    .references(() => ecommerceClientTable.id, {
-      onDelete: "cascade",
-    }),
-  invoiceCurrency: text().notNull(),
-  paymentCurrency: text().notNull(),
-  txHash: text().notNull(),
-  network: text().notNull(),
-  amount: text().notNull(),
-  customerInfo: json().$type<{
-    firstName?: string;
-    lastName?: string;
-    email?: string;
-    address?: {
-      street?: string;
-      city?: string;
-      state?: string;
-      postalCode?: string;
-      country?: string;
-    };
-  }>(),
-  reference: text(),
-  origin: text(),
-  createdAt: timestamp("created_at").defaultNow(),
-});
-
 export const requestTable = createTable("request", {
   id: text().primaryKey().notNull(),
   type: text().notNull(),
@@ -362,6 +327,41 @@ export const ecommerceClientTable = createTable(
     ),
   }),
 );
+
+export const clientPaymentTable = createTable("client_payment", {
+  id: text().primaryKey().notNull(),
+  userId: text()
+    .notNull()
+    .references(() => userTable.id, {
+      onDelete: "cascade",
+    }),
+  requestId: text().notNull(),
+  ecommerceClientId: text()
+    .notNull()
+    .references(() => ecommerceClientTable.id, {
+      onDelete: "cascade",
+    }),
+  invoiceCurrency: text().notNull(),
+  paymentCurrency: text().notNull(),
+  txHash: text().notNull(),
+  network: text().notNull(),
+  amount: text().notNull(),
+  customerInfo: json().$type<{
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    address?: {
+      street?: string;
+      city?: string;
+      state?: string;
+      postalCode?: string;
+      country?: string;
+    };
+  }>(),
+  reference: text(),
+  origin: text(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
 
 // Relationships
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -185,6 +185,11 @@ export const clientPaymentTable = createTable("client_payment", {
       onDelete: "cascade",
     }),
   requestId: text().notNull(),
+  ecommerceClientId: text()
+    .notNull()
+    .references(() => ecommerceClientTable.id, {
+      onDelete: "cascade",
+    }),
   invoiceCurrency: text().notNull(),
   paymentCurrency: text().notNull(),
   txHash: text().notNull(),
@@ -203,7 +208,6 @@ export const clientPaymentTable = createTable("client_payment", {
     };
   }>(),
   reference: text(),
-  clientId: text().notNull(),
   origin: text(),
   createdAt: timestamp("created_at").defaultNow(),
 });
@@ -435,6 +439,10 @@ export const clientPaymentRelations = relations(
     user: one(userTable, {
       fields: [clientPaymentTable.userId],
       references: [userTable.id],
+    }),
+    ecommerceClient: one(ecommerceClientTable, {
+      fields: [clientPaymentTable.ecommerceClientId],
+      references: [ecommerceClientTable.id],
     }),
   }),
 );

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -187,6 +187,8 @@ export const clientPaymentTable = createTable("client_payment", {
   requestId: text().notNull(),
   invoiceCurrency: text().notNull(),
   paymentCurrency: text().notNull(),
+  txHash: text().notNull(),
+  network: text().notNull(),
   amount: text().notNull(),
   customerInfo: json().$type<{
     firstName?: string;

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -177,6 +177,35 @@ export const paymentDetailsPayersTable = createTable("payment_details_payers", {
   createdAt: timestamp("created_at").defaultNow(),
 });
 
+export const clientPaymentTable = createTable("client_payment", {
+  id: text().primaryKey().notNull(),
+  userId: text()
+    .notNull()
+    .references(() => userTable.id, {
+      onDelete: "cascade",
+    }),
+  requestId: text().notNull(),
+  invoiceCurrency: text().notNull(),
+  paymentCurrency: text().notNull(),
+  amount: text().notNull(),
+  customerInfo: json().$type<{
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    address?: {
+      street?: string;
+      city?: string;
+      state?: string;
+      postalCode?: string;
+      country?: string;
+    };
+  }>(),
+  reference: text(),
+  clientId: text().notNull(),
+  origin: text(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 export const requestTable = createTable("request", {
   id: text().primaryKey().notNull(),
   type: text().notNull(),
@@ -322,6 +351,9 @@ export const ecommerceClientTable = createTable(
       table.userId,
       table.domain,
     ),
+    clientIdIndex: uniqueIndex("ecommerce_client_user_id_client_id_unique").on(
+      table.rnClientId,
+    ),
   }),
 );
 
@@ -332,6 +364,7 @@ export const userRelations = relations(userTable, ({ many }) => ({
   session: many(sessionTable),
   invoiceMe: many(invoiceMeTable),
   paymentDetailsPayers: many(paymentDetailsPayersTable),
+  clientPayments: many(clientPaymentTable),
 }));
 
 export const requestRelations = relations(requestTable, ({ one }) => ({
@@ -394,6 +427,16 @@ export const ecommerceClientRelations = relations(
   }),
 );
 
+export const clientPaymentRelations = relations(
+  clientPaymentTable,
+  ({ one }) => ({
+    user: one(userTable, {
+      fields: [clientPaymentTable.userId],
+      references: [userTable.id],
+    }),
+  }),
+);
+
 export const paymentDetailsRelations = relations(
   paymentDetailsTable,
   ({ one, many }) => ({
@@ -430,3 +473,4 @@ export type PaymentDetailsPayers = InferSelectModel<
 >;
 export type RecurringPayment = InferSelectModel<typeof recurringPaymentTable>;
 export type EcommerceClient = InferSelectModel<typeof ecommerceClientTable>;
+export type ClientPayment = InferSelectModel<typeof clientPaymentTable>;

--- a/src/server/routers/ecommerce.ts
+++ b/src/server/routers/ecommerce.ts
@@ -8,7 +8,7 @@ import {
 import { and, eq, not } from "drizzle-orm";
 import { ulid } from "ulid";
 import { z } from "zod";
-import { ecommerceClientTable } from "../db/schema";
+import { clientPaymentTable, ecommerceClientTable } from "../db/schema";
 import { protectedProcedure, router } from "../trpc";
 
 export const ecommerceRouter = router({
@@ -149,4 +149,16 @@ export const ecommerceRouter = router({
         throw toTRPCError(error);
       }
     }),
+  getAllClientPayments: protectedProcedure.query(async ({ ctx }) => {
+    const { db, user } = ctx;
+    try {
+      const clientPayments = await db.query.clientPaymentTable.findMany({
+        where: eq(clientPaymentTable.userId, user.id),
+      });
+
+      return clientPayments;
+    } catch (error) {
+      throw toTRPCError(error);
+    }
+  }),
 });

--- a/src/server/routers/ecommerce.ts
+++ b/src/server/routers/ecommerce.ts
@@ -5,7 +5,7 @@ import {
   ecommerceClientApiSchema,
   editecommerceClientApiSchema,
 } from "@/lib/schemas/ecommerce";
-import { and, eq, not } from "drizzle-orm";
+import { and, eq, not, sql } from "drizzle-orm";
 import { ulid } from "ulid";
 import { z } from "zod";
 import { clientPaymentTable, ecommerceClientTable } from "../db/schema";
@@ -157,6 +157,21 @@ export const ecommerceRouter = router({
       });
 
       return clientPayments;
+    } catch (error) {
+      throw toTRPCError(error);
+    }
+  }),
+  getAllUserReceipts: protectedProcedure.query(async ({ ctx }) => {
+    const { db, user } = ctx;
+    try {
+      const receipts = await db
+        .select()
+        .from(clientPaymentTable)
+        .where(
+          sql`${clientPaymentTable.customerInfo}->>'email' = ${user.email}`,
+        );
+
+      return receipts;
     } catch (error) {
       throw toTRPCError(error);
     }

--- a/src/server/routers/ecommerce.ts
+++ b/src/server/routers/ecommerce.ts
@@ -154,6 +154,9 @@ export const ecommerceRouter = router({
     try {
       const clientPayments = await db.query.clientPaymentTable.findMany({
         where: eq(clientPaymentTable.userId, user.id),
+        with: {
+          ecommerceClient: true,
+        },
       });
 
       return clientPayments;
@@ -164,12 +167,12 @@ export const ecommerceRouter = router({
   getAllUserReceipts: protectedProcedure.query(async ({ ctx }) => {
     const { db, user } = ctx;
     try {
-      const receipts = await db
-        .select()
-        .from(clientPaymentTable)
-        .where(
-          sql`${clientPaymentTable.customerInfo}->>'email' = ${user.email}`,
-        );
+      const receipts = await db.query.clientPaymentTable.findMany({
+        where: sql`${clientPaymentTable.customerInfo}->>'email' = ${user.email}`,
+        with: {
+          ecommerceClient: true,
+        },
+      });
 
       return receipts;
     } catch (error) {


### PR DESCRIPTION
## Changes
- added new `clientPayment` entity that stores all payments made with a client id
- modified the webhook route to store a client payment instead of a general request if clientId is present on the webhook body
- implemented an overview of all payments for the manage view
- implemented an overview of all the user's "receipts" -> payments made via our API using clientIds

## Testing
It's going to be the easiest to test this alongside this [PR](https://github.com/RequestNetwork/rn-checkout/pull/35) running on `localhost:3001` and having easy invoice on 3000.

1. Create the default client ID and copy the value. Go to RN checkout and add something to your cart, get to the payment step.
2. Enter your client ID here, go over the payment flow. **NOTE: Use the same email for customer info as the email with which you're logged into Easy Invoice!!!**
<img width="1775" height="876" alt="image" src="https://github.com/user-attachments/assets/06e6b00d-3c42-4f07-8bf0-44f2e4216194" />
<img width="803" height="1396" alt="image" src="https://github.com/user-attachments/assets/acc7c655-f301-43c1-b502-6ab780e1d98c" />
3. Once a payment is done and you are on the success step, go over to easy invoice's sales table and refresh it. Verify that you get the sales in the table and you can filter (although we only have 1 merchant so far...)
<img width="2172" height="1499" alt="image" src="https://github.com/user-attachments/assets/ab4692f6-00b9-4261-b27a-aa7dd3e37e06" />
4. Also verify that you get this payment in your receipts tab
<img width="2405" height="1085" alt="image" src="https://github.com/user-attachments/assets/59d04e31-0b29-43a9-bd4c-3982336a5dd2" />

Resolves #152