### PR TITLE
fix: change highlight button text color to black for better contrast

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,7 +66,7 @@
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
     --highlight: 171 100% 42%;
-    --highlight-foreground: 0 0% 98%;
+    --highlight-foreground: 0 0% 3.9%;
   }
 }
 


### PR DESCRIPTION
## Summary

Changes the highlight button text color from white to black for improved readability on the mint green background.

## Problem

Light green (#00E6A1 / mint) buttons with white text have poor contrast, making button labels difficult to read, especially in dark mode.

## Solution

Updated `--highlight-foreground` CSS variable in dark mode from `0 0% 98%` (white) to `0 0% 3.9%` (black) in `src/app/globals.css`.

## Testing

- Verified button text is now black on mint green background
- Applies to all buttons using the highlight color variant

Fixes #178

<img width="1661" height="1038" alt="Screenshot 2025-12-16 at 3 43 01 PM" src="https://github.com/user-attachments/assets/d463524f-f7da-4c60-b15d-ea271c88d9a7" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated highlight colors in dark mode for improved contrast and better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->