### PR TITLE
feat: add fallback display if no amountInUSD and add protocol fee

### DIFF
--- a/src/app/(dashboard)/invoices/[ID]/_components/payment-route.tsx
+++ b/src/app/(dashboard)/invoices/[ID]/_components/payment-route.tsx
@@ -1,5 +1,6 @@
 import { Tooltip } from "@/components/ui/tooltip";
 import type { PaymentRoute as PaymentRouteType } from "@/lib/types";
+import { utils } from "ethers";
 import { ArrowRight, Globe, Info, Zap } from "lucide-react";
 import Image from "next/image";
 
@@ -89,12 +90,26 @@ export function PaymentRoute({
                   ? "Gas Fee"
                   : fee.type === "crosschain"
                     ? "Crosschain Fee"
-                    : "Platform Fee"}
+                    : fee.type === "protocol"
+                      ? "Protocol Fee"
+                      : "Platform Fee"}
               </div>
             </div>
             <div className="text-right ml-2">
               <div className="font-medium">
-                {Number(fee.amountInUSD).toFixed(6)} USD
+                {fee.amountInUSD != null
+                  ? `${Number(fee.amountInUSD).toFixed(6)} USD`
+                  : (() => {
+                      const amount = fee.amount;
+                      const currency = fee.currency?.toUpperCase() || "";
+                      if (amount.includes(".")) {
+                        return `${Number(amount).toFixed(6)} ${currency}`;
+                      }
+                      if (currency === "ETH") {
+                        return `${utils.formatUnits(amount, 18)} ETH`;
+                      }
+                      return `${Number(amount).toFixed(4)} ${currency}`;
+                    })()}
               </div>
             </div>
           </div>

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -13,7 +13,7 @@ export interface PaymentRoute {
   isCryptoToFiat?: boolean;
   platformFee?: number;
   feeBreakdown?: {
-    type: "gas" | "crosschain" | "platform";
+    type: "gas" | "crosschain" | "platform" | "protocol";
     stage: "sending" | "overall";
     provider: string;
     amount: string;


### PR DESCRIPTION
### Protocol fee addition

![CleanShot 2026-01-14 at 13.39.02.png](https://app.graphite.com/user-attachments/assets/079c5a1b-10c0-4f74-b45b-68686ea3131a.png)

### Fallback Fix (Toolip was relying only in `amountInUsd` which is not available in all cases)  


![CleanShot 2026-01-14 at 13.40.12.png](https://app.graphite.com/user-attachments/assets/24139d8b-8f3d-4bd7-8062-6ea61583cb31.png)

### TL;DR

Added support for protocol fees and improved fee display formatting in the invoice payment route component.

### What changed?

- Added a new fee type `protocol` to the `feeBreakdown` type definition
- Enhanced the fee display logic in the payment route component to:
    - Show "Protocol Fee" label for fees of type `protocol`
    - Improve currency display formatting based on the fee's currency and amount
    - Handle cases where `amountInUSD` is not available by falling back to the native currency amount
    - Format ETH values appropriately when they exceed 1e12 (converting from wei to ETH)

### How to test?

1. Navigate to an invoice detail page with various fee types
2. Verify that protocol fees are correctly labeled as "Protocol Fee"
3. Check that fee amounts display correctly:
    - USD amounts should show with 6 decimal places
    - ETH amounts should show with 6 decimal places
    - Other currencies should show with 4 decimal places
    - Large ETH values (in wei) should be properly converted to ETH

### Why make this change?

This change improves the user experience by providing more accurate fee labeling and better formatting of fee amounts. It also adds support for protocol fees, which are a distinct fee type that needs to be properly represented in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added support for Protocol Fee type in invoice fee breakdown display.
    - Enhanced fee amount rendering with intelligent formatting based on currency type, including special handling for ETH values and improved data presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->