### PR TITLE
feat: pass connected payer wallet to the API to avoid having to approve all the time

### DIFF
--- a/src/app/(dashboard)/payouts/direct/_components/direct-payout.tsx
+++ b/src/app/(dashboard)/payouts/direct/_components/direct-payout.tsx
@@ -224,7 +224,10 @@ export function DirectPayment() {
 
       toast.info("Preparing payment...");
 
-      const paymentData = await pay(data);
+      const paymentData = await pay({
+        payerWallet: address,
+        ...data,
+      });
 
       dialogRef.current?.show({
         mode: "direct",

--- a/src/lib/schemas/payment.ts
+++ b/src/lib/schemas/payment.ts
@@ -44,6 +44,11 @@ export const paymentApiSchema = z.object({
         .describe("The wallet address of the payer"),
     })
     .optional(),
+  payerWallet: z
+    .string()
+    .refine(isEthereumAddress, "Invalid Ethereum wallet address")
+    .optional()
+    .describe("The connect wallet address of the payer"),
 });
 
 export type PaymentAPIValues = z.infer<typeof paymentApiSchema>;

--- a/src/server/routers/payment.ts
+++ b/src/server/routers/payment.ts
@@ -34,6 +34,11 @@ export const paymentRouter = router({
                 feeAddress,
               }
             : {}),
+          ...(input.payerWallet
+            ? {
+                payerWallet: input.payerWallet,
+              }
+            : {}),
         });
 
         return response.data;


### PR DESCRIPTION
### TL;DR

Added support for passing the connected wallet address as the payer wallet in direct payments.

### What changed?

- Modified the `DirectPayment` component to include the connected wallet address (`address`) in the payment data
- Added a new optional `payerWallet` field to the payment API schema with validation for Ethereum addresses
- Updated the payment router to include the `payerWallet` in the request when provided

### How to test?

1. Navigate to the direct payouts page
2. Connect your wallet
3. Create a direct payment
4. Verify that your wallet address is correctly passed as the payer wallet in the payment request

### Why make this change?

This change ensures that the connected wallet address is properly passed to the payment API, allowing the system to associate payments with the correct payer wallet. This improves payment tracking and attribution in direct payment flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional payer wallet address field to payment transactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->