### PR TITLE
fix: strict check for offramp_failed status

### DIFF
--- a/src/lib/invoice-status.ts
+++ b/src/lib/invoice-status.ts
@@ -55,13 +55,17 @@ export const getInvoiceTableStatusClass = (
     return "bg-green-50 text-green-700";
   }
 
-  if (status.includes("offramp_failed")) {
+  if (status === "offramp_failed") {
     return "bg-red-50 text-red-700";
-  }
+  }  
 
-  if (status.includes("offramp") || status === "processing") {
-    return "bg-orange-50 text-orange-700";
-  }
+  if (
+    status === "offramp_pending" ||
+    status === "offramp_initiated" ||
+    status === "processing"
+  ) {
+   return "bg-orange-50 text-orange-700";
+  }  
 
   return "bg-yellow-50 text-yellow-700";
 };
@@ -82,9 +86,13 @@ export const getPaymentSectionStatusClass = (
     return "bg-destructive/10 text-destructive";
   }
 
-  if (status.includes("offramp") || status === "processing") {
+  if (
+    status === "offramp_pending" ||
+    status === "offramp_initiated" ||
+    status === "processing"
+  ) {
     return "bg-warning/10 text-warning-foreground";
-  }
+  }  
 
   return "bg-primary/10 text-primary";
 };

--- a/src/lib/invoice-status.ts
+++ b/src/lib/invoice-status.ts
@@ -57,7 +57,7 @@ export const getInvoiceTableStatusClass = (
 
   if (status === "offramp_failed") {
     return "bg-red-50 text-red-700";
-  }  
+  }
 
   if (
     status === "offramp_pending" ||
@@ -65,7 +65,7 @@ export const getInvoiceTableStatusClass = (
     status === "processing"
   ) {
    return "bg-orange-50 text-orange-700";
-  }  
+  }
 
   return "bg-yellow-50 text-yellow-700";
 };
@@ -92,7 +92,7 @@ export const getPaymentSectionStatusClass = (
     status === "processing"
   ) {
     return "bg-warning/10 text-warning-foreground";
-  }  
+  }
 
   return "bg-primary/10 text-primary";
 };


### PR DESCRIPTION
Use strict equality for offramp_failed status instead of .includes() to avoid incorrect matching of other offramp states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invoice and payment status detection to more precisely surface offramp states (pending, initiated, failed) and processing status, ensuring more accurate and consistent status displays across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->